### PR TITLE
Oracle PoC smart contracts of infra and sample implementation

### DIFF
--- a/contracts/StoryDataSource.sol
+++ b/contracts/StoryDataSource.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.9;
 
-import "@chainlink/contracts/src/v0.8/ChainlinkClient.sol";
-import "@chainlink/contracts/src/v0.8/ConfirmedOwner.sol";
 import "./interfaces/IOffChainDataSource.sol";
 import { Strings } from '@openzeppelin/contracts/utils/Strings.sol';
 import "./interfaces/IStoryOracleCallback.sol";
@@ -13,23 +11,23 @@ contract StoryDataSource  is IOffChainDataSource, IStoryOracleCallback, StoryOra
     using StoryOracleHelper for StoryOracleHelper.Request;
     using Strings for uint256;
 
-    mapping(address=>string) public userData;
+    mapping(address=>string) private userData;
     mapping(bytes32=>address) public requests;
 
     event RequestData(bytes32 indexed requestId, string data);
 
     constructor()  {}
 
-    function getData(address user) public view override returns(string memory data) {
+    function getData(address user) external view override returns(string memory data) {
         return userData[user];
     }
 
-    function load(address user, string memory url, string memory path) public override {
+    function load(address user, string calldata url, string calldata path) public override {
         bytes32 requestId = requestUserData(url, path);
         requests[requestId] = user;
     }
 
-    function requestUserData(string memory url, string memory path) public returns (bytes32 requestId) {
+    function requestUserData(string calldata url, string calldata path) public returns (bytes32 requestId) {
         StoryOracleHelper.Request memory req = buildOracleRequest(
             this, url, path);
 

--- a/contracts/StoryDataSource.sol
+++ b/contracts/StoryDataSource.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+import "@chainlink/contracts/src/v0.8/ChainlinkClient.sol";
+import "@chainlink/contracts/src/v0.8/ConfirmedOwner.sol";
+import "./interfaces/IOffChainDataSource.sol";
+import { Strings } from '@openzeppelin/contracts/utils/Strings.sol';
+import "./interfaces/IStoryOracleCallback.sol";
+import "./libraries/StoryOracleClient.sol";
+import "./libraries/StoryOracleHelper.sol";
+
+contract StoryDataSource  is IOffChainDataSource, IStoryOracleCallback, StoryOracleClient {
+    using StoryOracleHelper for StoryOracleHelper.Request;
+    using Strings for uint256;
+
+    mapping(address=>string) public userData;
+    mapping(bytes32=>address) public requests;
+
+    event RequestData(bytes32 indexed requestId, string data);
+
+    constructor()  {}
+
+    function getData(address user) public view override returns(string memory data) {
+        return userData[user];
+    }
+
+    function load(address user, string memory url, string memory path) public override {
+        bytes32 requestId = requestUserData(url, path);
+        requests[requestId] = user;
+    }
+
+    function requestUserData(string memory url, string memory path) public returns (bytes32 requestId) {
+        StoryOracleHelper.Request memory req = buildOracleRequest(
+            this, url, path);
+
+        return sendOracleRequest(req);
+    }
+
+    function fulfill(
+        bytes32 _requestId,
+        string memory _data
+    ) public override recordOracleFulfillment(_requestId) {
+        emit RequestData(_requestId, _data);
+        userData[requests[_requestId]] = _data;
+    }
+}

--- a/contracts/interfaces/IOffChainDataSource.sol
+++ b/contracts/interfaces/IOffChainDataSource.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+interface IOffChainDataSource {
+    function getData(address user) external view returns (string memory data);
+    function load(address user, string memory url, string memory path) external;
+}

--- a/contracts/interfaces/IStoryOracleCallback.sol
+++ b/contracts/interfaces/IStoryOracleCallback.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+interface IStoryOracleCallback {
+    function fulfill(bytes32 _requestId, string memory _data) external;
+}

--- a/contracts/libraries/StoryOracleClient.sol
+++ b/contracts/libraries/StoryOracleClient.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "./StoryOracleHelper.sol";
+import "../interfaces/IStoryOracleCallback.sol";
+
+
+abstract contract StoryOracleClient {
+    using StoryOracleHelper for StoryOracleHelper.Request;
+
+    uint256 private requestCount = 1;
+    mapping(bytes32 => StoryOracleHelper.Request) private pendingRequests;
+
+    event StoryOracleFulfilled(bytes32 indexed requestId);
+    event StoryOracleCancelled(bytes32 indexed requestId);
+
+    event StoryOracleRequest(
+        bytes32 indexed requestId, // unique id of the oracle request, story oracle backend would call back with id.
+        address requester,  // address of smart contract which sending the oracle request
+        address callbackAddr,  // address of smart contract which implemented the callback function
+        string url,  // url of the json file
+        string path  // path the locate content within the json file
+    );
+
+    function buildOracleRequest(
+        IStoryOracleCallback oracleCallback,
+        string memory url,
+        string memory path
+    ) internal pure returns (StoryOracleHelper.Request memory) {
+        StoryOracleHelper.Request memory req;
+        return req.initialize(address(oracleCallback), url, path);
+    }
+
+    function cancelOracleRequest(bytes32 requestId) external {
+        delete pendingRequests[requestId];
+        emit StoryOracleCancelled(requestId);
+    }
+
+    function sendOracleRequest(StoryOracleHelper.Request memory req) internal returns (bytes32 requestId) {
+        uint256 nonce = requestCount;
+        requestCount = nonce + 1;
+        requestId = keccak256(abi.encodePacked(this, nonce));
+        req.id = requestId;
+        pendingRequests[requestId] = req;
+        emit StoryOracleRequest(req.id, address(this), req.callbackAddress, req.url, req.path);
+    }
+
+    function getNextRequestCount() public view returns (uint256) {
+        return requestCount;
+    }
+
+    modifier recordOracleFulfillment(bytes32 requestId) {
+        require(pendingRequests[requestId].id != 0, "the requestId does not exist");
+        delete pendingRequests[requestId];
+        emit StoryOracleFulfilled(requestId);
+        _;
+    }
+
+}

--- a/contracts/libraries/StoryOracleClient.sol
+++ b/contracts/libraries/StoryOracleClient.sol
@@ -18,8 +18,8 @@ abstract contract StoryOracleClient {
         bytes32 indexed requestId, // unique id of the oracle request, story oracle backend would call back with id.
         address requester,  // address of smart contract which sending the oracle request
         address callbackAddr,  // address of smart contract which implemented the callback function
-        string url,  // url of the json file
-        string path  // path the locate content within the json file
+        string indexed url,  // url of the json file
+        string indexed path  // path the locate content within the json file
     );
 
     function buildOracleRequest(

--- a/contracts/libraries/StoryOracleHelper.sol
+++ b/contracts/libraries/StoryOracleHelper.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+
+library StoryOracleHelper {
+    struct Request {
+        bytes32 id;
+        address callbackAddress;
+        uint256 nonce;
+        string url;
+        string path;
+    }
+
+    function initialize(
+        Request memory self,
+        address callbackAddr,
+        string memory url,
+        string memory path
+    ) internal pure returns (StoryOracleHelper.Request memory) {
+        self.callbackAddress = callbackAddr;
+        self.url = url;
+        self.path = path;
+        return self;
+    }
+}


### PR DESCRIPTION
Smart contracts of Story Oracle infra, interfaces, and sample data source.

**IOffChainDataSource** - interfaces that NFT off-chain data-source should implement:
-  load(),  trigger loading/refresh data through backend off-chain oracle.
- getData(), get off-chain data loaded/refreshed by load() above.

**IStoryOracleCallback** - interfaces that allow backend oracle to call back smart contracts:
- fulfill(), call back function

**StoryOracleClient** - Infra contract of Oracle that realizes protocol for interop with Story Oracle backend server as its client. It emits the event _StoryOracleRequest_ that is recognized by the oracle backend. 

```
event StoryOracleRequest(
    bytes32 indexed requestId, // unique id of the oracle request, story oracle backend would call back with id.
    address requester,  // address of smart contract which sending the oracle request
    address callbackAddr,  // address of smart contract which implemented the callback function
    string url,  // url of the json file
    string path  // path the locate content within the json file
);
```

**StoryOracleHelper** - help functions

**StoryDataSource** - Sample Story off-chain data source that is based on infra above so that support NFT can load/refresh off-chain data through Story Oracle Backend. 

### Test deployment:
StoryDataSource: https://goerli.etherscan.io/address/0xbEf2D967690A1e354c15E49C1841Ea2C09150E22#events

Sample of StoryOracleRequest event：https://goerli.etherscan.io/address/0xbEf2D967690A1e354c15E49C1841Ea2C09150E22#events
